### PR TITLE
feat: make read length variable in send_file

### DIFF
--- a/nanoweb.py
+++ b/nanoweb.py
@@ -27,11 +27,11 @@ async def error(request, code, reason):
     await request.write("<h1>%s</h1>" % (reason))
 
 
-async def send_file(request, filename):
+async def send_file(request, filename, segment=64):
     try:
         with open(filename, "r") as f:
             while True:
-                data = f.read(64)
+                data = f.read(segment)
                 if not data:
                     break
                 await request.write(data)


### PR DESCRIPTION
Thanks for the great module,

This patch provides a way to change the length per read in sned_file. A larger segment length greatly improves the throughput, especially when sending a large file (like minified JS). Since the original 64 Bytes length may be necessary for low-RAM systems, I did't break the compatibility for it and made it variable. It may be increased up to hundreds of Kilobytes unless MicroPython raises a MemoryError.