### PR TITLE
feat: return Server object

### DIFF
--- a/nanoweb.py
+++ b/nanoweb.py
@@ -173,4 +173,4 @@ class Nanoweb:
             await writer.aclose()
 
     async def run(self):
-        await asyncio.start_server(self.handle, self.address, self.port)
+        return await asyncio.start_server(self.handle, self.address, self.port)


### PR DESCRIPTION
This patch makes `Nanoweb.run` return a `Server` object. Users may call `Server.close()` to reuse the same port later, without resetting the entire board.

For example:

```py
from nanoweb import Nanoweb
app = Nanoweb()

@app.route('/')
async def handle(request):
    ...

async def main():
    print('Launching the API!')
    while True:
        async with await app.run():
            await func_that_returns_sometime()
        print('Re-launching the API!')
```

The interpreter calls `Server.close()` when the interpreter goes out from `async with` block and Nanoweb can use the same port and address as its endpoint.